### PR TITLE
echo -e not posix & fix colors

### DIFF
--- a/dist/rose-pine-dawn.sh
+++ b/dist/rose-pine-dawn.sh
@@ -1,22 +1,22 @@
 #!/bin/sh
 if [ "$TERM" = "linux" ]; then
-	/bin/echo -e "
-	\e]P0faf4ed
-	\e]P1b4637a
-	\e]P256949f
-	\e]P3ea9d34
-	\e]P4286983
-	\e]P5907aa9
-	\e]P6d7827e
-	\e]P7575279
-	\e]P8f2e9e1
-	\e]P9b4637a
-	\e]PA56949f
-	\e]PBea9d34
-	\e]PC286983
-	\e]PD907aa9
-	\e]PEd7827e
-	\e]PF575279
+	printf "
+	\033]P0faf4ed
+	\033]P1b4637a
+	\033]P2286983
+	\033]P3ea9d34
+	\033]P456949f
+	\033]P5907aa9
+	\033]P6d7827e
+	\033]P7575279
+	\033]P89893a5
+	\033]P9b4637a
+	\033]PA286983
+	\033]PBea9d34
+	\033]PC56949f
+	\033]PD907aa9
+	\033]PEd7827e
+	\033]PF575279
 	"
 	# get rid of artifacts
 	clear

--- a/dist/rose-pine-moon.sh
+++ b/dist/rose-pine-moon.sh
@@ -1,22 +1,22 @@
 #!/bin/sh
 if [ "$TERM" = "linux" ]; then
-	/bin/echo -e "
-	\e]P0232136
-	\e]P1eb6f92
-	\e]P29ccfd8
-	\e]P3f6c177
-	\e]P43e8fb0
-	\e]P5c4a7e7
-	\e]P6ea9a97
-	\e]P7e0def4
-	\e]P8393552
-	\e]P9eb6f92
-	\e]PA9ccfd8
-	\e]PBf6c177
-	\e]PC3e8fb0
-	\e]PDc4a7e7
-	\e]PEea9a97
-	\e]PFe0def4
+	printf "
+	\033]P0232136
+	\033]P1eb6f92
+	\033]P23e8fb0
+	\033]P3f6c177
+	\033]P49ccfd8
+	\033]P5c4a7e7
+	\033]P6ea9a97
+	\033]P7e0def4
+	\033]P86e6a86
+	\033]P9eb6f92
+	\033]PA3e8fb0
+	\033]PBf6c177
+	\033]PC9ccfd8
+	\033]PDc4a7e7
+	\033]PEea9a97
+	\033]PFe0def4
 	"
 	# get rid of artifacts
 	clear

--- a/dist/rose-pine.sh
+++ b/dist/rose-pine.sh
@@ -1,22 +1,22 @@
 #!/bin/sh
 if [ "$TERM" = "linux" ]; then
-	/bin/echo -e "
-	\e]P0191724
-	\e]P1eb6f92
-	\e]P29ccfd8
-	\e]P3f6c177
-	\e]P431748f
-	\e]P5c4a7e7
-	\e]P6ebbcba
-	\e]P7e0def4
-	\e]P826233a
-	\e]P9eb6f92
-	\e]PA9ccfd8
-	\e]PBf6c177
-	\e]PC31748f
-	\e]PDc4a7e7
-	\e]PEebbcba
-	\e]PFe0def4
+	printf "
+	\033]P0191724
+	\033]P1eb6f92
+	\033]P231748f
+	\033]P3f6c177
+	\033]P49ccfd8
+	\033]P5c4a7e7
+	\033]P6ebbcba
+	\033]P7e0def4
+	\033]P86e6a86
+	\033]P9eb6f92
+	\033]PA31748f
+	\033]PBf6c177
+	\033]PC9ccfd8
+	\033]PDc4a7e7
+	\033]PEebbcba
+	\033]PFe0def4
 	"
 	# get rid of artifacts
 	clear

--- a/template.sh
+++ b/template.sh
@@ -1,22 +1,22 @@
 #!/bin/sh
 if [ "$TERM" = "linux" ]; then
-	/bin/echo -e "
-	\e]P0$base
-	\e]P1$love
-	\e]P2$foam
-	\e]P3$gold
-	\e]P4$pine
-	\e]P5$iris
-	\e]P6$rose
-	\e]P7$text
-	\e]P8$overlay
-	\e]P9$love
-	\e]PA$foam
-	\e]PB$gold
-	\e]PC$pine
-	\e]PD$iris
-	\e]PE$rose
-	\e]PF$text
+	printf "
+	\033]P0$base
+	\033]P1$love
+	\033]P2$pine
+	\033]P3$gold
+	\033]P4$foam
+	\033]P5$iris
+	\033]P6$rose
+	\033]P7$text
+	\033]P8$muted
+	\033]P9$love
+	\033]PA$pine
+	\033]PB$gold
+	\033]PC$foam
+	\033]PD$iris
+	\033]PE$rose
+	\033]PF$text
 	"
 	# get rid of artifacts
 	clear


### PR DESCRIPTION
swap green (pine) and foam (blue) 
echo -e isn't posix compliant. switch to printf  
use \033 instead of \e which isn't portable  
use muted instead of overlay for bright black